### PR TITLE
Remove duplicate elastalert process

### DIFF
--- a/src/elastalert_server.js
+++ b/src/elastalert_server.js
@@ -65,9 +65,6 @@ export default class ElastalertServer {
         self._rulesController = new RulesController();
         self._testController = new TestController(self);
 
-        self._processController = new ProcessController();
-        self._processController.start();
-
         self._fileSystemController.createDirectoryIfNotExists(self.getDataFolder()).catch(function (error) {
           logger.error('Error creating data folder with error:', error);
         });


### PR DESCRIPTION
As discussed in https://github.com/bitsensor/elastalert/issues/3 , it appears that 2 elastalert processes are created. This changes the startup code so that only a single managed EA process is started.