### PR TITLE
Build directly from alpine:lastest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:latest as py-ea
-#ARG VERSION
+ARG ELASTALERT_VERSION=v0.1.28
+ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.
-#ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/$VERSION.zip
+ARG ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/$ELASTALERT_VERSION.zip
+ENV ELASTALERT_URL=${ELASTALERT_URL}
 # Elastalert home directory full path.
 ENV ELASTALERT_HOME /opt/elastalert
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,39 @@
-FROM ivankrizsan/elastalert AS py-ea
-# Uses BitSensor's elastalert, or yelp master if commented out
-# ENV ELASTALERT_URL https://github.com/bitsensor/yelp-elastalert/archive/master.zip
+FROM alpine:latest as py-ea
+#ARG VERSION
+# URL from which to download Elastalert.
+#ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/$VERSION.zip
+# Elastalert home directory full path.
+ENV ELASTALERT_HOME /opt/elastalert
+
+WORKDIR /opt
+
+RUN apk update && apk upgrade && \
+    apk add ca-certificates openssl-dev openssl python2-dev python2 py2-pip py2-yaml libffi-dev gcc musl-dev wget && \
+# Download and unpack Elastalert.
+    wget -O elastalert.zip "${ELASTALERT_URL}" && \
+    unzip elastalert.zip && \
+    rm elastalert.zip && \
+    mv e* "${ELASTALERT_HOME}"
+
+WORKDIR "${ELASTALERT_HOME}"
+
+# Install Elastalert.
+RUN python setup.py install && \
+    pip install -r requirements.txt
 
 FROM node:alpine
 MAINTAINER BitSensor <dev@bitsensor.io>
-EXPOSE 3030
+# Set this environment variable to True to set timezone on container start.
+ENV SET_CONTAINER_TIMEZONE False
+# Default container timezone as found under the directory /usr/share/zoneinfo/.
+ENV CONTAINER_TIMEZONE Etc/UTC
 
-RUN apk update && apk upgrade && apk add --no-cache python2 curl
+RUN apk update && apk upgrade && apk add --no-cache curl tzdata python2
 
 COPY --from=py-ea /usr/lib/python2.7/site-packages /usr/lib/python2.7/site-packages
 COPY --from=py-ea /opt/elastalert /opt/elastalert
+COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
 
-RUN mkdir server_data
 WORKDIR /opt/elastalert-server
 COPY . /opt/elastalert-server
 
@@ -21,4 +43,5 @@ COPY config/config.json config/config.json
 COPY rule_templates/ /opt/elastalert/rule_templates
 COPY elastalert_modules/ /opt/elastalert/elastalert_modules
 
+EXPOSE 3030
 ENTRYPOINT ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+v ?= v0.1.28
+
+all: build
+
+build:
+	docker pull alpine:latest && docker pull node:latest
+	docker build --build-arg ELASTALERT_VERSION=$(v) -t elastalert .
+
+server: build
+	docker run -it --rm -p 3030:3030 \
+	--net="host" \
+	elastalert:latest
+
+.PHONY: build

--- a/README.md
+++ b/README.md
@@ -58,11 +58,30 @@ ElastAlert supports additional arguments, that can be passed in the `config.json
 - [ElastAlert v0.0.96](https://github.com/Yelp/elastalert/tree/v0.0.96). We don't support other versions of ElastAlert, use them at your own risk.
 - [NodeJS 4.5.0](https://nodejs.org/en/download/) with NPM & NVM.
 
+## Building Docker image
+
+1. Clone the repository
+   ```bash
+   git clone https://github.com/bitsensor/elastalert.git && cd elastalert
+   ```
+2. Build the image
+   ```
+   docker build -t elastalert .
+   ```
+
+Custom Yelp's Elastalert version (a [release from github](https://github.com/Yelp/elastalert/releases)) e.g. `master` or `v0.1.28`:
+```bash
+docker build --build-arg ELASTALERT_VERSION=master -t elastalert .
+```
+Custom mirror:
+```bash
+docker build --build-arg ELASTALERT_URL=http://example.mirror.com/master.zip -t elastalert .
+```
+
 ## Building from source
 1. Clone the repository
     ```bash
-    git clone https://github.com/bitsensor/elastalert.git elastalert
-    cd elastalert
+    git clone https://github.com/bitsensor/elastalert.git && cd elastalert
     ```
 2. Run `nvm install "$(cat .node-version)"` to install & use the required NodeJS version.
 3. Run `npm install` to install all the dependencies.

--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ ElastAlert supports additional arguments, that can be passed in the `config.json
    ```bash
    git clone https://github.com/bitsensor/elastalert.git && cd elastalert
    ```
-2. Build the image
+2. Build the image using
    ```
+   make build
+   ```
+   which is equivalent of:
+   ```
+   docker pull alpine:latest && docker pull node:latest
    docker build -t elastalert .
    ```
 
 Custom Yelp's Elastalert version (a [release from github](https://github.com/Yelp/elastalert/releases)) e.g. `master` or `v0.1.28`:
 ```bash
-docker build --build-arg ELASTALERT_VERSION=master -t elastalert .
+make build v=v0.1.28
 ```
 Custom mirror:
 ```bash


### PR DESCRIPTION
This PR basically inlines used code from `ivankrizsan/elastalert`. I find it better to rely directly on official `alpine:latest` image that tends to be more up-to-date than any derivative images.

Thanks to:
```
COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
```
testing rules from container is possible
```
docker run -it --rm --entrypoint /bin/ash -w /opt/elastalert elastalert:latest
elastalert-test-rule rules/some_rule.yaml
```
Also I was experimenting with passing release number as `--build-arg VERSION=v0.1.28`, but that would probably break your automated builds.