### PR TITLE
HTTP Status code

### DIFF
--- a/src/controllers/process/index.js
+++ b/src/controllers/process/index.js
@@ -11,6 +11,7 @@ export default class ProcessController {
   constructor() {
     this._elastalertPath = config.get('elastalertPath');
     this._status = Status.IDLE;
+    this._code = 503; //Service Not Available (yet)
 
     /**
      * @type {ChildProcess}
@@ -21,6 +22,10 @@ export default class ProcessController {
 
   get status() {
     return this._status;
+  }
+
+  get httpCode() {
+    return this._code;
   }
 
   /**
@@ -88,6 +93,7 @@ export default class ProcessController {
 
     logger.info(`Started Elastalert (PID: ${this._process.pid})`);
     this._status = Status.READY;
+    this._code = 200;
 
     // Set listeners for ElastAlert exit
     this._process.on('exit', (code) => {
@@ -97,6 +103,7 @@ export default class ProcessController {
       } else {
         logger.error(`ElastAlert exited with code ${code}`);
         this._status = Status.ERROR;
+        this._code = 500;
       }
       this._process = null;
     });
@@ -105,6 +112,7 @@ export default class ProcessController {
     this._process.on('error', (err) => {
       logger.error(`ElastAlert error: ${err.toString()}`);
       this._status = Status.ERROR;
+      this._code = 500;
       this._process = null;
     });
   }
@@ -118,6 +126,7 @@ export default class ProcessController {
       logger.info(`Stopping ElastAlert (PID: ${this._process.pid})`);
       this._status = Status.CLOSING;
       this._process.kill('SIGINT');
+      this._code = 503; //Service Unavailable
     } else {
       // Do not do anything if ElastAlert is not running
       logger.info('ElastAlert is not running');

--- a/src/handlers/status/index.js
+++ b/src/handlers/status/index.js
@@ -7,6 +7,7 @@ export default function statusHandler(request, response) {
   var server = request.app.get('server');
   var status = server.processController.status;
 
+  response.statusCode = server.processController.httpCode;
   response.send({
     status: Status(status)
   });


### PR DESCRIPTION
Some monitoring systems decide application status solely based on HTTP code. In order to make sure that elastalert is up and running it would be good to be consistent. Currently response
```
{"status":"ERROR"}
```
comes with `HTTP/1.1 200` header.
This PR makes sure, that after switching to `ERROR` state `500` code is returned.
```
< HTTP/1.1 500 Internal Server Error
< X-Powered-By: Express
< Content-Type: application/json; charset=utf-8
< Content-Length: 18
< ETag: W/"12-mdXr7bKb/tVCY3xbcOthRmXlyhg"
< Date: Thu, 08 Feb 2018 13:22:49 GMT
< Connection: keep-alive

{"status":"ERROR"}
```

