### PR TITLE
Download api endpoint added

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,17 @@ This server exposes the following REST API's:
 - **[WIP] POST `/config`**
 
     Allows you to edit the ElastAlert configuration from `config.yaml` in `elastalertPath` (from the config). The required body to be send will be edited when the work on this API is done.
- 
+
+- **[WIP] POST `/download`**
+  
+    Allows you to download .tar archive with rules from HTTP endpoint. Archive will be downloaded,extracted and removed.
+    Please note, body should contain URL pointing to tar archive, with tar extension.	
+   
+    Usage example:
+	
+        ```curl -X POST localhost:3030/download -d "url=https://artifactory.com:443/artifactory/raw/rules/rules.tar"```
+ 	
+        
 ## Contributing
 Want to contribute to this project? Great! Please read our [contributing guidelines](CONTRIBUTING.md) before submitting an issue or a pull request.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "mkdirp": "^0.5.1",
     "object-resolve-path": "^1.1.1",
     "randomstring": "^1.1.5",
-    "raven": "^2.3.0"
+    "raven": "^2.3.0",
+    "tar": "^4.4.1",
+    "fs-extra": "^5.0.0",
+    "request-promise-native": "^1.0.5"
   },
   "devDependencies": {
     "eslint": "^4.17.0",

--- a/src/common/errors/rule_request_errors.js
+++ b/src/common/errors/rule_request_errors.js
@@ -41,3 +41,13 @@ export class RulesRootFolderNotCreatableError extends RequestError {
     super('rulesRootFolderNotCreatable', 'The rules folder wasn\'t found and couldn\'t be created by the file system.', 403);
   }
 }
+export class URLNotSentError extends RequestError {
+  constructor() {
+    super('URLNotSentError', 'URL is missing in the body', 400);
+  }  
+}
+export class URLNotPointingTar extends RequestError {
+  constructor() {
+    super('URLNotPointingTar', 'URL is not pointing to .tar file', 400);
+  }
+}

--- a/src/handlers/rules/id/download.js
+++ b/src/handlers/rules/id/download.js
@@ -1,0 +1,50 @@
+import RouteLogger from '../../../routes/route_logger';
+import {sendRequestError} from '../../../common/errors/utils';
+import {URLNotSentError,URLNotPointingTar} from '../../../common/errors/rule_request_errors';
+import path from 'path';
+
+let logger = new RouteLogger('/download');
+
+
+export default function downloadRulesHandler(request, response) {
+  /**
+   * @type {ElastalertServer}
+   */
+  let server = request.app.get('server');
+  let body = request.body;
+  
+
+  function _test_body(body){
+    if (!body||!body.url) {
+      return new URLNotSentError();
+    }
+    let filename = path.basename(body.url);
+    if (!filename.endsWith('.tar')){
+      return new URLNotPointingTar();
+    }
+    return body;
+  }
+ 
+  body=_test_body(body);
+  if(body.error){
+    logger.sendFailed(body.error);
+    sendRequestError(response, body.error);
+    return;
+  }
+
+
+  server.rulesController.downloadRules(body.url)
+    .then(() => {
+      logger.sendSuccessful();
+      return response.send({
+        downloaded: true,
+        extracted: true,
+        url: body.url
+      });
+    })
+    .catch((error) => {
+      logger.sendFailed(error);
+      sendRequestError(response, error);
+    });
+  
+}

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,6 +4,7 @@ import controlHandler from '../handlers/status/control';
 import errorsHandler from '../handlers/status/errors';
 import rulesHandler from '../handlers/rules';
 import ruleGetHandler from '../handlers/rules/id/get';
+import downloadRulesHandler from '../handlers/rules/id/download';
 import rulePostHandler from '../handlers/rules/id/post';
 import ruleDeleteHandler from '../handlers/rules/id/delete';
 import templatesHandler from '../handlers/templates';
@@ -68,6 +69,11 @@ let routes = [
     path: 'config',
     method: ['GET', 'POST'],
     handler: [configGetHandler, configPostHandler]
+  },
+  {
+    path: 'download',
+    method: ['POST'],
+    handler: [downloadRulesHandler]
   }
 ];
 


### PR DESCRIPTION
/download api endpoint is added. It allows to download tar archive with rules from HTTP endpoints. Rules will be extracted to rules folder