### PR TITLE
Add json format for test results + other enhancements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ This server exposes the following REST API's:
 
     Returns metadata from elasticsearch related to elasalert's state. `:type` should be one of: elastalert_status, elastalert, elastalert_error, or silence. See [docs about the elastalert metadata index](https://elastalert.readthedocs.io/en/latest/elastalert_status.html).
 
+- **GET `/mapping/:index`**
+
+    Returns field mapping from elasticsearch for a given index. 
+
 - **[WIP] GET `/config`**
 
     Gets the ElastAlert configuration from `config.yaml` in `elastalertPath` (from the config).

--- a/README.md
+++ b/README.md
@@ -200,7 +200,13 @@ This server exposes the following REST API's:
           "days": "1"
           
           // Whether to send real alerts
-          "alert": false
+          "alert": false,
+
+          // Return results in structured JSON
+          "format": "json",
+
+          // Limit returned results to this amount
+          "maxResults": 1000
         }
       }
       ``` 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ This server exposes the following REST API's:
       }
       ``` 
     
+- **GET `/metadata/:type`**
+
+    Returns metadata from elasticsearch related to elasalert's state. `:type` should be one of: elastalert_status, elastalert, elastalert_error, or silence. See [docs about the elastalert metadata index](https://elastalert.readthedocs.io/en/latest/elastalert_status.html).
+
 - **[WIP] GET `/config`**
 
     Gets the ElastAlert configuration from `config.yaml` in `elastalertPath` (from the config).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ You can use the following config options:
   "dataPath": { // The path to a folder that the server can use to store data and temporary files.
     "relative": true, // Whether to use a path relative to the `elastalertPath` folder.
     "path": "/server_data" // The path to the data folder.
-  }
+  },
+  "es_host": "elastalert", // For getting metadata and field mappings, connect to this ES server
+  "es_port": 9200, // Port for above
+  "writeback_index": "elastalert_status" // Writeback index to examine for /metadata endpoint
 }
 ```
  

--- a/config/config.json
+++ b/config/config.json
@@ -12,5 +12,8 @@
   "templatesPath": {
     "relative": true,
     "path": "/rule_templates"
-  }
+  },
+  "es_host": "elastalert",
+  "es_port": 9200,
+  "writeback_index": "elastalert_status"
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-register": "^6.14.0",
     "body-parser": "^1.15.2",
     "bunyan": "^1.8.1",
+    "cors": "^2.8.4",
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
     "joi": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
     "joi": "^13.1.2",
-    "js-yaml": "^3.12.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "object-resolve-path": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "body-parser": "^1.15.2",
     "bunyan": "^1.8.1",
     "cors": "^2.8.4",
+    "elasticsearch": "^15.1.1",
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
     "joi": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
     "joi": "^13.1.2",
+    "js-yaml": "^3.12.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "object-resolve-path": "^1.1.1",

--- a/src/common/config/schema.js
+++ b/src/common/config/schema.js
@@ -3,6 +3,9 @@ import Joi from 'joi';
 
 const schema = Joi.object().keys({
   'appName': Joi.string().default('elastalert-server'),
+  'es_host': Joi.string().default('elastalert'),
+  'es_port': Joi.number().default(9200),
+  'writeback_index': Joi.string().default('elastalert_status'),
   'port': Joi.number().default(3030),
   'elastalertPath': Joi.string().default('/opt/elastalert'),
   'rulesPath': Joi.object().keys({

--- a/src/common/elasticsearch_client.js
+++ b/src/common/elasticsearch_client.js
@@ -1,0 +1,22 @@
+import yaml from 'js-yaml';
+import fs from 'fs';
+import process from 'process';
+import elasticsearch from 'elasticsearch';
+
+export function getConfig() {
+  try {
+    var appRoot = process.cwd();
+    var config = yaml.safeLoad(fs.readFileSync(appRoot + '/config/elastalert.yaml', 'utf8'));
+    return config;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export function getClient() {
+  var config = getConfig();
+  var client = new elasticsearch.Client({
+    hosts: [ `http://${config.es_host}:${config.es_port}`]
+  });
+  return client;
+}

--- a/src/common/elasticsearch_client.js
+++ b/src/common/elasticsearch_client.js
@@ -1,22 +1,9 @@
-import yaml from 'js-yaml';
-import fs from 'fs';
-import process from 'process';
 import elasticsearch from 'elasticsearch';
-
-export function getConfig() {
-  try {
-    var appRoot = process.cwd();
-    var config = yaml.safeLoad(fs.readFileSync(appRoot + '/config/elastalert.yaml', 'utf8'));
-    return config;
-  } catch (e) {
-    console.error(e);
-  }
-}
+import config from './config';
 
 export function getClient() {
-  var config = getConfig();
   var client = new elasticsearch.Client({
-    hosts: [ `http://${config.es_host}:${config.es_port}`]
+    hosts: [ `http://${config.get('es_host')}:${config.get('es_port')}`]
   });
   return client;
 }

--- a/src/controllers/test/index.js
+++ b/src/controllers/test/index.js
@@ -33,6 +33,10 @@ export default class TestController {
 
           processOptions.push('-m', 'elastalert.test_rule', '--config', 'config.yaml', tempFilePath, '--days', options.days);
 
+          if (options.format === 'json') {
+            processOptions.push('--formatted-output');
+          }
+
           if (options.alert) {
             processOptions.push('--alert');
           }

--- a/src/controllers/test/index.js
+++ b/src/controllers/test/index.js
@@ -70,7 +70,12 @@ export default class TestController {
 
             testProcess.on('exit', function (statusCode) {
               if (statusCode === 0) {
-                resolve(stdoutLines.join('\n'));
+                if (options.format === 'json') {
+                  resolve(stdoutLines.join());
+                }
+                else {
+                  resolve(stdoutLines.join('\n'));
+                }
               } else {
                 reject(stderrLines.join('\n'));
                 logger.error(stderrLines.join('\n'));

--- a/src/controllers/test/index.js
+++ b/src/controllers/test/index.js
@@ -71,7 +71,7 @@ export default class TestController {
             testProcess.on('exit', function (statusCode) {
               if (statusCode === 0) {
                 if (options.format === 'json') {
-                  resolve(stdoutLines.join());
+                  resolve(stdoutLines.join(''));
                 }
                 else {
                   resolve(stdoutLines.join('\n'));

--- a/src/controllers/test/index.js
+++ b/src/controllers/test/index.js
@@ -37,6 +37,11 @@ export default class TestController {
             processOptions.push('--formatted-output');
           }
 
+          if (options.maxResults > 0) {
+            processOptions.push('--max-query-size');
+            processOptions.push(options.maxResults);
+          }
+
           if (options.alert) {
             processOptions.push('--alert');
           }

--- a/src/elastalert_server.js
+++ b/src/elastalert_server.js
@@ -9,6 +9,7 @@ import ProcessController from './controllers/process';
 import RulesController from './controllers/rules';
 import TemplatesController from './controllers/templates';
 import TestController from './controllers/test';
+import cors from 'cors';
 
 let logger = new Logger('Server');
 
@@ -58,6 +59,7 @@ export default class ElastalertServer {
     // Start the server when the config is loaded
     config.ready(function () {
       try {
+        self._express.use(cors());
         self._express.use(bodyParser.json());
         self._express.use(bodyParser.urlencoded({ extended: true }));
         self._setupRouter();

--- a/src/handlers/mapping/get.js
+++ b/src/handlers/mapping/get.js
@@ -1,12 +1,12 @@
 import { getClient } from '../../common/elasticsearch_client';
 
-var client = getClient();
-
 export default function metadataHandler(request, response) {
   /**
    * @type {ElastalertServer}
    */
   
+  var client = getClient();
+
   client.indices.getMapping({
     index: request.params.index
   }).then(function(resp) {

--- a/src/handlers/mapping/get.js
+++ b/src/handlers/mapping/get.js
@@ -1,0 +1,20 @@
+import { getClient } from '../../common/elasticsearch_client';
+
+var client = getClient();
+
+export default function metadataHandler(request, response) {
+  /**
+   * @type {ElastalertServer}
+   */
+  
+  client.indices.getMapping({
+    index: request.params.index
+  }).then(function(resp) {
+    response.send(resp);
+  }, function(err) {
+    response.send({
+      error: err
+    });
+  });
+
+}

--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -1,0 +1,31 @@
+import { getConfig, getClient } from '../../common/elasticsearch_client';
+
+var config = getConfig();
+var client = getClient();
+
+export default function metadataHandler(request, response) {
+  /**
+   * @type {ElastalertServer}
+   */
+  
+  client.search({
+    index: config.writeback_index,
+    type: request.params.type,
+    body: {
+      from : request.query.from || 0, 
+      size : request.query.size || 10,
+      query: {
+        match_all: {}
+      },
+      sort: [{ '@timestamp': { order: 'desc' } }]
+    }
+  }).then(function(resp) {
+    resp.hits.hits = resp.hits.hits.map(h => h._source);
+    response.send(resp.hits);
+  }, function(err) {
+    response.send({
+      error: err
+    });
+  });
+
+}

--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -1,7 +1,6 @@
-import { getConfig, getClient } from '../../common/elasticsearch_client';
+import config from '../../common/config';
+import { getClient } from '../../common/elasticsearch_client';
 
-var config = getConfig();
-var client = getClient();
 
 function getQueryString(request) {
   if (request.params.type === 'elastalert_error') {
@@ -16,8 +15,10 @@ export default function metadataHandler(request, response) {
   /**
    * @type {ElastalertServer}
    */
+  var client = getClient();
+
   client.search({
-    index: config.writeback_index,
+    index: config.get('writeback_index'),
     type: request.params.type,
     body: {
       from : request.query.from || 0, 

--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -3,19 +3,29 @@ import { getConfig, getClient } from '../../common/elasticsearch_client';
 var config = getConfig();
 var client = getClient();
 
+function getQueryString(request) {
+  if (request.params.type === 'elastalert_error') {
+    return '*:*';
+  }
+  else {
+    return `rule_name:${request.query.rule_name || '*'}`;
+  }
+}
+
 export default function metadataHandler(request, response) {
   /**
    * @type {ElastalertServer}
    */
-  
   client.search({
     index: config.writeback_index,
     type: request.params.type,
     body: {
       from : request.query.from || 0, 
-      size : request.query.size || 10,
+      size : request.query.size || 100,
       query: {
-        match_all: {}
+        query_string: {
+          query: getQueryString(request)
+        }
       },
       sort: [{ '@timestamp': { order: 'desc' } }]
     }

--- a/src/handlers/templates/id/post.js
+++ b/src/handlers/templates/id/post.js
@@ -26,8 +26,8 @@ export default function templatePostHandler(request, response) {
         });
     })
     .catch(function (error) {
-      if (error.error === 'ruleNotFound') {
-        server.templatesController.createRule(request.params.id, body)
+      if (error.error === 'templateNotFound') {
+        server.templatesController.createTemplate(request.params.id, body)
           .then(function () {
             logger.sendSuccessful();
             response.send({

--- a/src/handlers/test/post.js
+++ b/src/handlers/test/post.js
@@ -8,7 +8,8 @@ let logger = new RouteLogger('/test', 'POST');
 const optionsSchema = Joi.object().keys({
   testType: Joi.string().valid('all', 'schemaOnly', 'countOnly').default('all'),
   days: Joi.number().min(1).default(1),
-  alert: Joi.boolean().default(false)
+  alert: Joi.boolean().default(false),
+  format: Joi.string().default('')
 }).default();
 
 function analyzeRequest(request) {

--- a/src/handlers/test/post.js
+++ b/src/handlers/test/post.js
@@ -9,7 +9,8 @@ const optionsSchema = Joi.object().keys({
   testType: Joi.string().valid('all', 'schemaOnly', 'countOnly').default('all'),
   days: Joi.number().min(1).default(1),
   alert: Joi.boolean().default(false),
-  format: Joi.string().default('')
+  format: Joi.string().default(''),
+  maxResults: Joi.number().default(0)
 }).default();
 
 function analyzeRequest(request) {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -14,6 +14,7 @@ import templateDeleteHandler from '../handlers/templates/id/delete';
 import testPostHandler from '../handlers/test/post';
 import configGetHandler from '../handlers/config/get';
 import configPostHandler from '../handlers/config/post';
+import metadataHandler from '../handlers/metadata/get';
 
 /**
  * A server route.
@@ -74,6 +75,11 @@ let routes = [
     path: 'download',
     method: ['POST'],
     handler: [downloadRulesHandler]
+  },
+  {
+    path: 'metadata/:type',
+    method: ['GET'],
+    handler: [metadataHandler]
   }
 ];
 

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -15,6 +15,7 @@ import testPostHandler from '../handlers/test/post';
 import configGetHandler from '../handlers/config/get';
 import configPostHandler from '../handlers/config/post';
 import metadataHandler from '../handlers/metadata/get';
+import mappingHandler from '../handlers/mapping/get';
 
 /**
  * A server route.
@@ -80,6 +81,11 @@ let routes = [
     path: 'metadata/:type',
     method: ['GET'],
     handler: [metadataHandler]
+  },
+  {
+    path: 'mapping/:index',
+    method: ['GET'],
+    handler: [mappingHandler]
   }
 ];
 


### PR DESCRIPTION
This adds support for structured JSON test results that was just added to the master branch of elastalert.

Please see https://github.com/Yelp/elastalert/pull/1897

When using the new option format=json, test results will look like this:
```javascript
{
  "hits": 11,
  "terms": {
    "syslog_severity_code": 6,
    "service": "Vpxa",
    "tags": [],
    "syslog_severity": "informational",
    "@timestamp": "2018-09-10T18:16:23.461Z",
    "syslog_facility": "user-level",
    "host": "c5014-cesx121.ms",
    "@version": "1",
    "dept_id": "ms",
    "message": "- - [Originator@68762018-09-10T18:16:23.450Z Vpxa: verbose vpxa[FFC9AAE0] [Originator@6876[VpxaHalCnxHostagent::ProcessUpdate] Applying updates from 11843011 to 11843012 (at 11843011)",
    "syslog_pri": "14",
    "type": "syslog",
    "syslog_facility_code": 1
  },
  "name": "test321",
  "success": true,
  "days": 1
}
```
