### PR TITLE
Add new endpoint /metadata to return elastalert's metadata from the writeback index

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ This server exposes the following REST API's:
       }
       ``` 
     
+- **GET `/metadata/:type`**
+
+    Returns metadata from elasticsearch related to elasalert's state. `:type` should be one of: elastalert_status, elastalert, elastalert_error, or silence. See [docs about the elastalert metadata index](https://elastalert.readthedocs.io/en/latest/elastalert_status.html).
+
 - **[WIP] GET `/config`**
 
     Gets the ElastAlert configuration from `config.yaml` in `elastalertPath` (from the config).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
     "joi": "^13.1.2",
+    "js-yaml": "^3.12.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "object-resolve-path": "^1.1.1",

--- a/src/common/elasticsearch_client.js
+++ b/src/common/elasticsearch_client.js
@@ -1,0 +1,22 @@
+import yaml from 'js-yaml';
+import fs from 'fs';
+import process from 'process';
+import elasticsearch from 'elasticsearch';
+
+export function getConfig() {
+  try {
+    var appRoot = process.cwd();
+    var config = yaml.safeLoad(fs.readFileSync(appRoot + '/config/elastalert.yaml', 'utf8'));
+    return config;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export function getClient() {
+  var config = getConfig();
+  var client = new elasticsearch.Client({
+    hosts: [ `http://${config.es_host}:${config.es_port}`]
+  });
+  return client;
+}

--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -1,0 +1,31 @@
+import { getConfig, getClient } from '../../common/elasticsearch_client';
+
+var config = getConfig();
+var client = getClient();
+
+export default function metadataHandler(request, response) {
+  /**
+   * @type {ElastalertServer}
+   */
+  
+  client.search({
+    index: config.writeback_index,
+    type: request.params.type,
+    body: {
+      from : request.query.from || 0, 
+      size : request.query.size || 10,
+      query: {
+        match_all: {}
+      },
+      sort: [{ '@timestamp': { order: 'desc' } }]
+    }
+  }).then(function(resp) {
+    resp.hits.hits = resp.hits.hits.map(h => h._source);
+    response.send(resp.hits);
+  }, function(err) {
+    response.send({
+      error: err
+    });
+  });
+
+}

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -14,6 +14,7 @@ import templateDeleteHandler from '../handlers/templates/id/delete';
 import testPostHandler from '../handlers/test/post';
 import configGetHandler from '../handlers/config/get';
 import configPostHandler from '../handlers/config/post';
+import metadataHandler from '../handlers/metadata/get';
 
 /**
  * A server route.
@@ -74,6 +75,11 @@ let routes = [
     path: 'download',
     method: ['POST'],
     handler: [downloadRulesHandler]
+  },
+  {
+    path: 'metadata/:type',
+    method: ['GET'],
+    handler: [metadataHandler]
   }
 ];
 


### PR DESCRIPTION
This will add the ability for API clients to get a log of data about the alerts