### PR TITLE
Update Docker build to use python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest as py-ea
-ARG ELASTALERT_VERSION=v0.2.0b2
+ARG ELASTALERT_VERSION=v0.2.1
 ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.
 ARG ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/$ELASTALERT_VERSION.zip
@@ -9,7 +9,7 @@ ENV ELASTALERT_HOME /opt/elastalert
 
 WORKDIR /opt
 
-RUN apk add --update --no-cache ca-certificates openssl-dev openssl python2-dev python2 py2-pip py2-yaml libffi-dev gcc musl-dev wget && \
+RUN apk add --update --no-cache ca-certificates openssl-dev openssl python3-dev python3 py3-pip py3-yaml libffi-dev gcc musl-dev wget && \
 # Download and unpack Elastalert.
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \
@@ -21,17 +21,17 @@ WORKDIR "${ELASTALERT_HOME}"
 # Install Elastalert.
 # see: https://github.com/Yelp/elastalert/issues/1654
 RUN sed -i 's/jira>=1.0.10/jira>=1.0.10,<1.0.15/g' setup.py && \
-    python setup.py install && \
-    pip install -r requirements.txt
+    python3 setup.py install && \
+    pip3 install -r requirements.txt
 
 FROM node:alpine
 LABEL maintainer="BitSensor <dev@bitsensor.io>"
 # Set timezone for this container
 ENV TZ Etc/UTC
 
-RUN apk add --update --no-cache curl tzdata python2 make libmagic
+RUN apk add --update --no-cache curl tzdata python2 python3 make libmagic
 
-COPY --from=py-ea /usr/lib/python2.7/site-packages /usr/lib/python2.7/site-packages
+COPY --from=py-ea /usr/lib/python3.7/site-packages /usr/lib/python3.7/site-packages
 COPY --from=py-ea /opt/elastalert /opt/elastalert
 COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as py-ea
+FROM python:3.6-alpine as py-ea
 ARG ELASTALERT_VERSION=v0.2.1
 ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.
@@ -9,7 +9,7 @@ ENV ELASTALERT_HOME /opt/elastalert
 
 WORKDIR /opt
 
-RUN apk add --update --no-cache ca-certificates openssl-dev openssl python3-dev python3 py3-pip py3-yaml libffi-dev gcc musl-dev wget && \
+RUN apk add --update --no-cache ca-certificates openssl-dev openssl libffi-dev gcc musl-dev wget && \
 # Download and unpack Elastalert.
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \
@@ -31,9 +31,9 @@ ENV TZ Etc/UTC
 
 RUN apk add --update --no-cache curl tzdata python2 python3 make libmagic
 
-COPY --from=py-ea /usr/lib/python3.7/site-packages /usr/lib/python3.7/site-packages
+COPY --from=py-ea /usr/local/lib/python3.6/site-packages /usr/lib/python3.6/site-packages
 COPY --from=py-ea /opt/elastalert /opt/elastalert
-COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
+COPY --from=py-ea /usr/local/bin/elastalert* /usr/bin/
 
 WORKDIR /opt/elastalert-server
 COPY . /opt/elastalert-server

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-v ?= v0.2.0b2
+v ?= v0.2.1
 
 all: build
 
 build:
 	docker pull alpine:latest && docker pull node:alpine
-	docker build --build-arg ELASTALERT_VERSION=$(v) -t elastalert .
+	docker build --build-arg ELASTALERT_VERSION=$(v) -t elastalert-python3 .
 
 server: build
 	docker run -it --rm -p 3030:3030 \

--- a/src/controllers/process/index.js
+++ b/src/controllers/process/index.js
@@ -43,7 +43,7 @@ export default class ProcessController {
 
     // Create ElastAlert index if it doesn't exist yet
     logger.info('Creating index');
-    var indexCreate = spawnSync('python', ['-m', 'elastalert.create_index', '--index', config.get('writeback_index'), '--old-index', ''], {
+    var indexCreate = spawnSync('python3', ['-m', 'elastalert.create_index', '--index', config.get('writeback_index'), '--old-index', ''], {
       cwd: this._elastalertPath
     });
 
@@ -92,7 +92,7 @@ export default class ProcessController {
 
     logger.info('Starting elastalert with arguments ' + (startArguments.join(' ') || '[none]'));
 
-    this._process = spawn('python', ['-m', 'elastalert.elastalert'].concat(startArguments), {
+    this._process = spawn('python3', ['-m', 'elastalert.elastalert'].concat(startArguments), {
       cwd: this._elastalertPath
     });
 

--- a/src/controllers/test/index.js
+++ b/src/controllers/test/index.js
@@ -57,7 +57,7 @@ export default class TestController {
 
 
           try {
-            let testProcess = spawn('python', processOptions, {
+            let testProcess = spawn('python3', processOptions, {
               cwd: self._elastalertPath
             });
 


### PR DESCRIPTION
Based on the changes by @nqkdev in #117, but including needed changes to launch elastalert under Python 3 while still using Python 2 for node-gyp. 