### PR TITLE
Use latest version of elastalert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,41 @@
-FROM alpine:latest as py-ea
-ARG ELASTALERT_VERSION=v0.2.0b2
+FROM alpine:3.9 as py-ea
+ARG ELASTALERT_VERSION=v0.2.1
 ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.
 ARG ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/$ELASTALERT_VERSION.zip
 ENV ELASTALERT_URL=${ELASTALERT_URL}
 # Elastalert home directory full path.
-ENV ELASTALERT_HOME /opt/elastalert
+ENV ELASTALERT_HOME=/opt/elastalert
 
 WORKDIR /opt
 
-RUN apk add --update --no-cache ca-certificates openssl-dev openssl python2-dev python2 py2-pip py2-yaml libffi-dev gcc musl-dev wget && \
+RUN apk add --update --no-cache ca-certificates openssl-dev openssl python3-dev=3.6.8-r2 python3=3.6.8-r2 libffi-dev gcc musl-dev wget && \
 # Download and unpack Elastalert.
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \
     rm elastalert.zip && \
-    mv e* "${ELASTALERT_HOME}"
+    mv e* "${ELASTALERT_HOME}" && \
+    python3 -m ensurepip && \
+    pip3 install --upgrade pip && \
+    pip3 install pyyaml
 
 WORKDIR "${ELASTALERT_HOME}"
 
 # Install Elastalert.
 # see: https://github.com/Yelp/elastalert/issues/1654
 RUN sed -i 's/jira>=1.0.10/jira>=1.0.10,<1.0.15/g' setup.py && \
-    python setup.py install && \
-    pip install -r requirements.txt
+    python3 setup.py install && \
+    pip3 install -r requirements.txt
 
 FROM node:alpine
 LABEL maintainer="BitSensor <dev@bitsensor.io>"
 # Set timezone for this container
 ENV TZ Etc/UTC
 
-RUN apk add --update --no-cache curl tzdata python2 make libmagic
+RUN apk add --update --no-cache curl tzdata python2 python3=3.6.8-r2 make libmagic && \
+    ln -sf python3 /usr/bin/python
 
-COPY --from=py-ea /usr/lib/python2.7/site-packages /usr/lib/python2.7/site-packages
+COPY --from=py-ea /usr/lib/python3.6/site-packages /usr/lib/python3.6/site-packages
 COPY --from=py-ea /opt/elastalert /opt/elastalert
 COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
 


### PR DESCRIPTION
This PR updates the Dockerfile to use the latest version of yelp/elastalert.

There were some caveats though regarding the used Python version.
yelp/elastalert is now built using Python 3(.6).

When using `alpine:latest as py-ea`, one will get Alpine:3.10, where `apk add python3` will be Python 3.7.4, which is not available in Alpine 3.9 which `node:alpine` is based upon.
That's why I'm pinning the Python version to exact `python=3.6.8-r2` which exists in both.

I tested this image on our production cluster and can confirm that it works as expected.