### PR TITLE
py2-yaml conflict solve temporary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as py-ea
+FROM alpine:3.8 as py-ea
 ARG ELASTALERT_VERSION=v0.2.0b2
 ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.


### PR DESCRIPTION
#147 issue temporary solved

The latest dockerfile was created in May last year

but current alpine version was created Dec last year

so i tried to build with alpine 3.8ver that was created May in last year

it's success

but i think  this solution is temporary